### PR TITLE
Bugfix: Initialize var

### DIFF
--- a/blocks/src/link-group/index.php
+++ b/blocks/src/link-group/index.php
@@ -31,7 +31,7 @@ function render( $attributes, $content, $block ) {
         return '';
     }
 
-    $output .= sprintf( '<a href="%1$s"%2$s%3$s>', 
+    $output = sprintf( '<a href="%1$s"%2$s%3$s>', 
         \esc_url( $attributes['url'] ), 
         ( isset( $attributes['linkTarget'] ) && $attributes['linkTarget'] ) ? ' target="' . $attributes['linkTarget'] . '"' : '',
         $wrapper_attributes


### PR DESCRIPTION
- [Bugfix: Initialize var](https://github.com/madeofpeople/the-territory-site-functionality/pull/29/commits/dd2955dbcc673efee7b90dedc78228130e671c3f)

Fixes  
`Warning: Undefined variable $output in /Users/thiago/repos/territory/app/public/wp-content/plugins/the-territory-site-functionality/blocks/src/link-group/index.php on line 34`